### PR TITLE
allow multiple delayed_job processes

### DIFF
--- a/delayed_job/attributes/default.rb
+++ b/delayed_job/attributes/default.rb
@@ -1,1 +1,4 @@
 default[:delayed_job][:timeout] = 60
+default[:delayed_job][:bin] = "bin/delayed_job"
+default[:delayed_job][:suffix] = ""
+default[:delayed_job][:options] = ""

--- a/delayed_job/recipes/default.rb
+++ b/delayed_job/recipes/default.rb
@@ -12,6 +12,27 @@ include_recipe 'deploy'
 node[:deploy].each do |application, deploy|
   deploy = node[:deploy][application]
 
+  global = node[:delayed_job] || {}
+
+  if deploy[:delayed_job].is_a?(Array)
+    index = 0
+    workers = deploy[:delayed_job].map do |dj|
+      index += 1
+      identifier = dj[:identifier] || index
+      {
+        :timeout => dj[:timeout] || global[:timeout],
+        :bin => dj[:bin] || global[:bin],
+        :identifier => identifier,
+        :suffix => ".#{identifier}",
+        :options => dj[:options] || global[:options]
+      }
+    end
+  else
+    # For backwards compatability with existing json
+    # :delayed_job => true
+    workers = [global]
+  end
+
   template "/etc/monit.d/#{application}_delayed_job.monitrc" do
     source 'delayed_job.monitrc.erb'
     owner 'root'
@@ -23,7 +44,7 @@ node[:deploy].each do |application, deploy|
       :dir => deploy[:deploy_to],
       :user => deploy[:user],
       :group => deploy[:group],
-      :timeout => node[:delayed_job][:timeout]
+      :workers => workers
     )
     only_if { deploy[:delayed_job] }
   end

--- a/delayed_job/recipes/restart.rb
+++ b/delayed_job/recipes/restart.rb
@@ -7,13 +7,7 @@
 # All rights reserved - Do Not Redistribute
 #
 
-node[:deploy].each do |application, deploy|
-  deploy = node[:deploy][application]
-
-  bash "delayed-job-restart-#{application}" do
-    user 'root'
-    code "monit restart #{application}_delayed_job"
-    only_if { deploy[:delayed_job] }
-  end
+bash "restart-all-delayed_job" do
+  user 'root'
+  code "monit -g delayed_job restart"
 end
-

--- a/delayed_job/templates/default/delayed_job.monitrc.erb
+++ b/delayed_job/templates/default/delayed_job.monitrc.erb
@@ -1,5 +1,8 @@
-check process <%= @app %>_delayed_job with pidfile <%= @dir %>/shared/pids/delayed_job.pid
-  start program = "/bin/sh -c 'cd <%= @dir %>/current; /usr/bin/env PATH=/usr/local/bin:$PATH RAILS_ENV=<%= @env %> <%= @dir %>/current/bin/delayed_job start'"
-    as uid <%= @user %> and gid <%= @group %> with timeout <%= @timeout %> seconds
-  stop program = "/bin/sh -c 'cd <%= @dir %>/current; /usr/bin/env PATH=/usr/local/bin:$PATH RAILS_ENV=<%= @env %> <%= @dir %>/current/bin/delayed_job stop'"
-    as uid <%= @user %> and gid <%= @group %> with timeout <%= @timeout %> seconds
+<% @workers.each do |worker| %>
+check process <%= @app %>_delayed_job<%= worker[:suffix] %> with pidfile <%= @dir %>/shared/pids/delayed_job<%= worker[:suffix] %>.pid
+  start program = "/bin/sh -c 'cd <%= @dir %>/current; /usr/bin/env PATH=/usr/local/bin:$PATH RAILS_ENV=<%= @env %> <%= @dir %>/current/<%= worker[:bin] %> start <%= "--identifier=#{worker[:identifier]}" if worker[:identifier] %> <%= worker[:options] %>'"
+    as uid <%= @user %> and gid <%= @group %> with timeout <%= worker[:timeout] %> seconds
+  stop program = "/bin/sh -c 'cd <%= @dir %>/current; /usr/bin/env PATH=/usr/local/bin:$PATH RAILS_ENV=<%= @env %> <%= @dir %>/current/<%= worker[:bin] %> stop <%= "--identifier=#{worker[:identifier]}" if worker[:identifier] %>'"
+  as uid <%= @user %> and gid <%= @group %> with timeout <%= worker[:timeout] %> seconds
+  group delayed_job
+<% end %>


### PR DESCRIPTION
This allows specifying multiple delayed job instances per application, and allows per application and per-worker customization.

``` json
{
  "deploy": {
    "my_app": {
      "delayed_job": [
        {
          "identifier": "regular",
          "timeout": 60
        },
        {
          "identifier": "priority",
          "options": "--min-priority 10",
          "timeout": 30
        }
      ]
    }
  }
}
```

delayed_job monit scripts are now all put into the delayed_job group, which delayed_job::restart now uses.
