### PR TITLE
Add dotenv overload to unicorn conf.

### DIFF
--- a/unicorn/templates/default/unicorn.conf.erb
+++ b/unicorn/templates/default/unicorn.conf.erb
@@ -22,6 +22,11 @@ GC.copy_on_write_friendly = true if GC.respond_to?(:copy_on_write_friendly=)
 # more info: https://willj.net/2011/08/02/fixing-the-gemfile-not-found-bundlergemfilenotfound-error/
 before_exec do |server|
   ENV['BUNDLE_GEMFILE'] = "<%= @deploy[:deploy_to]%>/current/Gemfile"
+
+  # Reload ENV variables.
+  if defined?(Dotenv)
+    Dotenv.overload ".env.<%= @deploy[:rails_env] %>", ".env"
+  end
 end
 
 before_fork do |server, worker|


### PR DESCRIPTION
Requires copying over unicorn.conf.erb from the default cookbooks. Also, requires Dotenv ~> 0.10.0.
