### PR TITLE
Add nginx config to allow for a maintenance page

### DIFF
--- a/unicorn/templates/default/nginx_unicorn_web_app.erb
+++ b/unicorn/templates/default/nginx_unicorn_web_app.erb
@@ -29,7 +29,7 @@ server {
     add_header Access-Control-Allow-Origin *;
   }
 
-  location ~* ^/assets/ {
+  location ~* ^/(assets|static)/ {
     gzip_static on;
     expires     max;
     add_header  Cache-Control public;
@@ -53,6 +53,10 @@ server {
     }
     <% end %>
 
+    if (-f $document_root/offline) {
+      return 503;
+    }
+
     # If you don't find the filename in the static files
     # Then request it from the unicorn server
     if (!-f $request_filename) {
@@ -68,9 +72,14 @@ server {
     deny all;
   }
 
-  error_page 500 502 503 504 /500.html;
+  error_page 500 502 504 /500.html;
   location = /500.html {
     root <%= @application[:absolute_document_root] %>;
+  }
+
+  error_page 503 @maintenance;
+  location @maintenance {
+    rewrite ^(.*)$ /maintenance.html break;
   }
 }
 
@@ -99,7 +108,7 @@ server {
     return 444;
   }
 
-  location ~* ^/assets/ {
+  location ~* ^/(assets|static)/ {
     gzip_static on;
     expires     max;
     add_header  Cache-Control public;
@@ -111,6 +120,10 @@ server {
     proxy_set_header Host $http_host;
     proxy_redirect off;
 
+    if (-f $document_root/offline) {
+      return 503;
+    }
+
     # If you don't find the filename in the static files
     # Then request it from the unicorn server
     if (!-f $request_filename) {
@@ -119,9 +132,14 @@ server {
     }
   }
 
-  error_page 500 502 503 504 /500.html;
+  error_page 500 502 504 /500.html;
   location = /500.html {
     root <%= @application[:absolute_document_root] %>;
+  }
+
+  error_page 503 @maintenance;
+  location @maintenance {
+    rewrite ^(.*)$ /maintenance.html break;
   }
 }
 <% end %>


### PR DESCRIPTION
Relatively simple change. It ensures that anything under `$root/static` will be rendered and if there's a `$root/offline` file it will return 503 for all requests and render `$root/maintenance.html`. This allows applications to store any necessary images, CSS or JS in `$root/static` and still have it rendered correctly on the maintenance page.

I chose `$root/static` in favor of sticking things in `/assets/` because that folder is used for compiled assets. However, since the maintenance page isn't part of the rails application it won't use sprockets for its assets. In the most recent versions of Rails you can't serve both non-digested and digested assets. As such, I felt the simplest approach was to have a secondary folder called static where assets for error pages could be placed.
