### PR TITLE
Override the rails restart command

### DIFF
--- a/deploy/attributes/customize.rb
+++ b/deploy/attributes/customize.rb
@@ -1,0 +1,1 @@
+override[:opsworks][:rails_stack][:restart_command] = '../../shared/scripts/unicorn restart'


### PR DESCRIPTION
Previously we always overrode this using the Stack Settings custom json. As of opsworks chef 11.10, this attribute is declared as "normal" instead of as "default", so the stack settings will not be used.

This changes our stacks to always use the restart command. It's something we've used on every stack we've made, and is a generally better default.
