### PR TITLE
restart delayed jobs properly if settings change

### DIFF
--- a/delayed_job/recipes/deploy.rb
+++ b/delayed_job/recipes/deploy.rb
@@ -1,0 +1,30 @@
+include_recipe 'delayed_job::default'
+
+node[:deploy].each do |application, deploy|
+
+  # This stops all delayed jobs which have a pid file
+  bash "delayed_job-#{application}-stop" do
+    cwd "#{deploy[:deploy_to]}/current"
+    user 'deploy'
+    code 'bin/delayed_job stop'
+
+    action :nothing
+  end
+
+  bash "delayed_job-#{application}-reload" do
+    user 'root'
+
+    # We unmonitor the delayed jobs because we will stop them manually
+    # They will become monitored again when restarted
+    code <<CODE
+monit -g delayed_job unmonitor
+monit reload
+CODE
+
+    action :nothing
+    subscribes :run, "template[/etc/monit.d/#{application}_delayed_job.monitrc]", :immediately
+    notifies :run, "bash[delayed_job-#{application}-stop]", :immediately
+  end
+end
+
+include_recipe 'delayed_job::restart'

--- a/delayed_job/recipes/restart.rb
+++ b/delayed_job/recipes/restart.rb
@@ -9,5 +9,8 @@
 
 bash "restart-all-delayed_job" do
   user 'root'
-  code "monit -g delayed_job restart"
+  code <<CODE
+monit -g delayed_job monitor
+monit -g delayed_job restart
+CODE
 end


### PR DESCRIPTION
If our delayed_job monitrc changes in any way, we will:

* unmonitor the jobs
* reload monit
* stop them via `bin/delayed_job stop`, which will stop ALL instances
* remonitor and restart the new jobs with the new settings