### PR TITLE
Sepcify RAILS_ENV for delayed job stop in deploy

### DIFF
--- a/delayed_job/recipes/deploy.rb
+++ b/delayed_job/recipes/deploy.rb
@@ -6,7 +6,7 @@ node[:deploy].each do |application, deploy|
   bash "delayed_job-#{application}-stop" do
     cwd "#{deploy[:deploy_to]}/current"
     user 'deploy'
-    code 'bin/delayed_job stop'
+    code "RAILS_ENV=#{deploy[:rails_env]} bin/delayed_job stop"
 
     action :nothing
   end


### PR DESCRIPTION
For some reason on OpsWorks with Chef 11.10 this tries to run in 'development'
env, so this change specifies the env explicitly when stopping delayed job
in the deploy recipe.
