### PR TITLE
Add custom Sinatra cookbook

### DIFF
--- a/sinatra/README.md
+++ b/sinatra/README.md
@@ -6,8 +6,11 @@ custom layer in AWS Opsworks. It requires a bit of custom JSON to get working.
 ## Usage
 
 Create a custom layer in the AWS console as one normally would, and add the
-`sinatra::configure` recipe to the "Configure" step and the `sinatra::deploy`
-recipe to the "Deploy" step.
+following recipes at the following steps:
+
+  - Setup: `sinatra::setup`
+  - Configure: `sinatra::configure`
+  - Deploy: `sinatra::deploy`
 
 ---
 

--- a/sinatra/README.md
+++ b/sinatra/README.md
@@ -8,7 +8,7 @@ custom layer in AWS Opsworks. It requires a bit of custom JSON to get working.
 Create a custom layer in the AWS console as one normally would, and add the
 following recipes at the following steps:
 
-  - Setup: `sinatra::setup`
+  - Setup: `ruby::default`, `sinatra::setup`
   - Configure: `sinatra::configure`
   - Deploy: `sinatra::deploy`
 

--- a/sinatra/README.md
+++ b/sinatra/README.md
@@ -1,0 +1,37 @@
+# Sinatra Cookbook
+
+This cookbook provides the necessary recipes to get a Sinatra app deployed on a
+custom layer in AWS Opsworks. It requires a bit of custom JSON to get working.
+
+## Usage
+
+Create a custom layer in the AWS console as one normally would, and add the
+`sinatra::configure` recipe to the "Configure" step and the `sinatra::deploy`
+recipe to the "Deploy" step.
+
+---
+
+There's a bit of custom JSON you'll need for various things:
+
+```javascript
+{
+  // Tell the bundler recipes we want to install bundler
+  "opsworks_bundler": {
+    "manage_package": "true"
+  },
+
+  "nginx": {
+    // The unicorn socket is owned by `deploy` user with group `apache`.
+    // We need nginx to match, otherwise upstream proxying fails.
+    "user": "deploy apache"
+  },
+
+  // For our recipes, we expect the `application_type` to be `rack`.
+  "deploy": {
+    "my_app": {
+      "application_type": "rack",
+      "rack_env": "production"
+    }
+  }
+}
+```

--- a/sinatra/metadata.rb
+++ b/sinatra/metadata.rb
@@ -1,0 +1,4 @@
+name "sinatra"
+description "Recipes to help deploy a sinatra app"
+depends "deploy"
+version "0.1"

--- a/sinatra/metadata.rb
+++ b/sinatra/metadata.rb
@@ -1,4 +1,5 @@
 name "sinatra"
 description "Recipes to help deploy a sinatra app"
 depends "deploy"
+depends "nginx"
 version "0.1"

--- a/sinatra/recipes/configure.rb
+++ b/sinatra/recipes/configure.rb
@@ -7,6 +7,8 @@
 # All rights reserved - Do Not Redistribute
 #
 
+include_recipe "nginx"
+
 node[:deploy].each do |application, _|
   deploy = node[:deploy][application]
 

--- a/sinatra/recipes/configure.rb
+++ b/sinatra/recipes/configure.rb
@@ -7,8 +7,6 @@
 # All rights reserved - Do Not Redistribute
 #
 
-include_recipe "nginx"
-
 node[:deploy].each do |application, _|
   deploy = node[:deploy][application]
 
@@ -18,19 +16,4 @@ node[:deploy].each do |application, _|
     action :nothing
   end
 
-  # Steal the database.yml template from the opsworks rails cookbook
-  template "#{deploy[:deploy_to]}/shared/config/database.yml" do
-    source "database.yml.erb"
-    cookbook "rails"
-    mode "0660"
-    group deploy[:group]
-    owner deploy[:user]
-    variables(database: deploy[:database], environment: deploy[:rack_env])
-
-    notifies :run, "execute[restart Sinatra application #{application}]"
-
-    only_if do
-      deploy[:database][:host].present? && File.directory?("#{deploy[:deploy_to]}/shared/config/")
-    end
-  end
 end

--- a/sinatra/recipes/configure.rb
+++ b/sinatra/recipes/configure.rb
@@ -1,0 +1,34 @@
+#
+# Cookbook Name:: sinatra
+# Recipe:: configure
+#
+# Copyright 2015, Stembolt
+#
+# All rights reserved - Do Not Redistribute
+#
+
+node[:deploy].each do |application, _|
+  deploy = node[:deploy][application]
+
+  execute "restart Sinatra application #{application}" do
+    cwd deploy[:current_path]
+    command node[:opsworks][:rails_stack][:restart_command]
+    action :nothing
+  end
+
+  # Steal the database.yml template from the opsworks rails cookbook
+  template "#{deploy[:deploy_to]}/shared/config/database.yml" do
+    source "database.yml.erb"
+    cookbook "rails"
+    mode "0660"
+    group deploy[:group]
+    owner deploy[:user]
+    variables(database: deploy[:database], environment: deploy[:rack_env])
+
+    notifies :run, "execute[restart Sinatra application #{application}]"
+
+    only_if do
+      deploy[:database][:host].present? && File.directory?("#{deploy[:deploy_to]}/shared/config/")
+    end
+  end
+end

--- a/sinatra/recipes/deploy.rb
+++ b/sinatra/recipes/deploy.rb
@@ -15,12 +15,6 @@ node[:deploy].each do |application, _|
     next
   end
 
-  opsworks_deploy_dir do
-    user deploy[:user]
-    group deploy[:group]
-    path deploy[:deploy_to]
-  end
-
   nginx_web_app application do
     cookbook "unicorn"
     docroot deploy[:absolute_document_root]

--- a/sinatra/recipes/deploy.rb
+++ b/sinatra/recipes/deploy.rb
@@ -39,6 +39,12 @@ node[:deploy].each do |application, _|
     app application
   end
 
+  execute "ln -s #{deploy[:deploy_to]}/shared/config/database.yml #{deploy[:deploy_to]}/current/config/database.yml" do
+    only_if do
+      File.exist? "#{deploy[:deploy_to]}/shared/config/database.yml"
+    end
+  end
+
   execute "bundle exec rake db:migrate" do
     cwd deploy[:deploy_to] + "/current"
     only_if do
@@ -48,11 +54,5 @@ node[:deploy].each do |application, _|
 
   execute "bundle install" do
     cwd deploy[:deploy_to] + "/current"
-  end
-
-  execute "ln -s #{deploy[:deploy_to]}/shared/config/database.yml #{deploy[:deploy_to]}/current/config/database.yml" do
-    only_if do
-      File.exist? "#{deploy[:deploy_to]}/shared/config/database.yml"
-    end
   end
 end

--- a/sinatra/recipes/deploy.rb
+++ b/sinatra/recipes/deploy.rb
@@ -55,4 +55,10 @@ node[:deploy].each do |application, _|
       deploy[:database].present?
     end
   end
+
+  execute "restart Sinatra application #{application}" do
+    cwd deploy[:current_path]
+    command node[:opsworks][:rails_stack][:restart_command]
+    action :nothing
+  end
 end

--- a/sinatra/recipes/deploy.rb
+++ b/sinatra/recipes/deploy.rb
@@ -53,6 +53,5 @@ node[:deploy].each do |application, _|
   execute "restart Sinatra application #{application}" do
     cwd deploy[:current_path]
     command node[:opsworks][:rails_stack][:restart_command]
-    action :nothing
   end
 end

--- a/sinatra/recipes/deploy.rb
+++ b/sinatra/recipes/deploy.rb
@@ -53,5 +53,6 @@ node[:deploy].each do |application, _|
   execute "restart Sinatra application #{application}" do
     cwd deploy[:current_path]
     command node[:opsworks][:rails_stack][:restart_command]
+    environment({"RACK_ENV" => deploy[:rack_env]})
   end
 end

--- a/sinatra/recipes/deploy.rb
+++ b/sinatra/recipes/deploy.rb
@@ -45,14 +45,14 @@ node[:deploy].each do |application, _|
     end
   end
 
+  execute "bundle install" do
+    cwd deploy[:deploy_to] + "/current"
+  end
+
   execute "bundle exec rake db:migrate" do
     cwd deploy[:deploy_to] + "/current"
     only_if do
       deploy[:database].present?
     end
-  end
-
-  execute "bundle install" do
-    cwd deploy[:deploy_to] + "/current"
   end
 end

--- a/sinatra/recipes/deploy.rb
+++ b/sinatra/recipes/deploy.rb
@@ -1,0 +1,51 @@
+#
+# Cookbook Name:: sinatra
+# Recipe:: deploy
+#
+# Copyright 2015, Stembolt
+#
+# All rights reserved - Do Not Redistribute
+#
+
+node[:deploy].each do |application, _|
+  deploy = node[:deploy][application]
+
+  if deploy[:application_type] != 'rack'
+    Chef::Log.debug("Skipping application #{application} as it is not of type 'rack'")
+    next
+  end
+
+  opsworks_deploy_dir do
+    user deploy[:user]
+    group deploy[:group]
+    path deploy[:deploy_to]
+  end
+
+  nginx_web_app application do
+    cookbook "unicorn"
+    docroot deploy[:absolute_document_root]
+    server_name deploy[:domains]
+    server_aliases []
+    rails_env deploy[:rack_env]
+    mounted_at deploy[:mounted_at]
+    ssl_certificate_ca deploy[:ssl_certificate_ca]
+    deploy deploy
+    template "nginx_unicorn_web_app.erb"
+    application deploy
+  end
+
+  opsworks_deploy do
+    deploy_data deploy
+    app application
+  end
+
+  execute "bundle install" do
+    cwd deploy[:deploy_to] + "/current"
+  end
+
+  execute "ln -s #{deploy[:deploy_to]}/shared/config/database.yml #{deploy[:deploy_to]}/current/config/database.yml" do
+    only_if do
+      File.exist? "#{deploy[:deploy_to]}/shared/config/database.yml"
+    end
+  end
+end

--- a/sinatra/recipes/deploy.rb
+++ b/sinatra/recipes/deploy.rb
@@ -39,6 +39,13 @@ node[:deploy].each do |application, _|
     app application
   end
 
+  execute "bundle exec rake db:migrate" do
+    cwd deploy[:deploy_to] + "/current"
+    only_if do
+      deploy[:database].present?
+    end
+  end
+
   execute "bundle install" do
     cwd deploy[:deploy_to] + "/current"
   end

--- a/sinatra/recipes/setup.rb
+++ b/sinatra/recipes/setup.rb
@@ -2,8 +2,6 @@
 # refuses to run if the application_type is not "rails", we need to do it
 # ourselves...
 
-include_recipe "nginx"
-
 node[:deploy].each do |application, deploy|
   next if deploy[:application_type] != 'rack'
 

--- a/sinatra/recipes/setup.rb
+++ b/sinatra/recipes/setup.rb
@@ -1,0 +1,39 @@
+# All of this is basically the same as AWS's `unicorn::rails`, but since it
+# refuses to run if the application_type is not "rails", we need to do it
+# ourselves...
+
+include_recipe "nginx"
+
+node[:deploy].each do |application, deploy|
+  next if deploy[:application_type] != 'rack'
+
+  template "#{deploy[:deploy_to]}/shared/scripts/unicorn" do
+    cookbook "unicorn"
+    mode '0755'
+    owner deploy[:user]
+    group deploy[:group]
+    source "unicorn.service.erb"
+    variables(:deploy => deploy, :application => application)
+  end
+
+  service "unicorn_#{application}" do
+    start_command "#{deploy[:deploy_to]}/shared/scripts/unicorn start"
+    stop_command "#{deploy[:deploy_to]}/shared/scripts/unicorn stop"
+    restart_command "#{deploy[:deploy_to]}/shared/scripts/unicorn restart"
+    status_command "#{deploy[:deploy_to]}/shared/scripts/unicorn status"
+    action :nothing
+  end
+
+  template "#{deploy[:deploy_to]}/shared/config/unicorn.conf" do
+    cookbook "unicorn"
+    mode '0644'
+    owner deploy[:user]
+    group deploy[:group]
+    source "unicorn.conf.erb"
+    variables(
+      :deploy => deploy,
+      :application => application,
+      :environment => OpsWorks::Escape.escape_double_quotes(deploy[:environment_variables])
+    )
+  end
+end

--- a/sinatra/recipes/setup.rb
+++ b/sinatra/recipes/setup.rb
@@ -7,6 +7,12 @@ include_recipe "nginx"
 node[:deploy].each do |application, deploy|
   next if deploy[:application_type] != 'rack'
 
+  opsworks_deploy_dir do
+    user deploy[:user]
+    group deploy[:group]
+    path deploy[:deploy_to]
+  end
+
   template "#{deploy[:deploy_to]}/shared/scripts/unicorn" do
     cookbook "unicorn"
     mode '0755'

--- a/sinatra/recipes/setup.rb
+++ b/sinatra/recipes/setup.rb
@@ -7,6 +7,10 @@ include_recipe "nginx"
 node[:deploy].each do |application, deploy|
   next if deploy[:application_type] != 'rack'
 
+  opsworks_deploy_user do
+    deploy_data deploy
+  end
+
   opsworks_deploy_dir do
     user deploy[:user]
     group deploy[:group]


### PR DESCRIPTION
Since Rails layers just don't _quite_ work for Sinatra apps (not to mention you can't have two), we need to be able to do the things necessary to deploy Sinatra to a "custom" layer type. A lot of this is basically pieced together from various other Opsworks default cookbooks, and some of it is custom because wow how about those default recipes.

These have been tested and confirmed working on a fresh stack with no other layers, but will likely not conflict with any of the Rails default layers if you have them (no guarantees; this is chef).
