### PR TITLE
Fix readme example

### DIFF
--- a/delayed_job/README.md
+++ b/delayed_job/README.md
@@ -37,7 +37,7 @@ Two processes running all queues.
   "deploy": {
     "myapp": {
       "delayed_job": [{
-        "options": "-n 2"
+        "worker_count": 2
       }],
 ```
 


### PR DESCRIPTION
The first example will fail from the daemons gem with the error:

Cannot specify both --number-of-workers and --identifier
(ArgumentError)

This updates the readme with the correct method of spawning multiple
workers seen

here:
https://github.com/StemboltHQ/frt-opsworks-cookbooks/blob/master/delayed_job/recipes/template.rb#L13
